### PR TITLE
Bump node from 10.17.0 to 14.17.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:10.17.0-alpine
+FROM node:14.17.0-alpine3.11
 
 RUN apk add --no-cache cairo cairo-dev build-base

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # docker-node-alpine-cairo
 
-Container image based node:10.17.0-alpine with
+Container image based node:14.17.0-alpine3.11 with
 cairo/cairo-dev installed
+
+## Supported Tags:
+
+- [`14.17.0-alpine3.11` `latest` (*Dockerfile*)](https://github.com/frodeaa/node-alpine-cairo/blob/master/Dockerfile)
+- [`10.17.0` (*Dockerfile*)](https://github.com/frodeaa/node-alpine-cairo/blob/2d6c5df26c39d340bc01f390b95cabf3d7e117f0/Dockerfile)
+- [`8.11.2` (*Dockerfile*)](https://github.com/frodeaa/node-alpine-cairo/blob/8.11.2/Dockerfile)


### PR DESCRIPTION
Fixes: https://github.com/frodeaa/node-alpine-cairo/issues/1